### PR TITLE
docs(readme): update instruction section for system-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# system-config
-public config file 
+# instruction
+
+used for store the system config
+
+such as the yazi, zsh, nushell, etc.

--- a/src/nushell/config.nu
+++ b/src/nushell/config.nu
@@ -1,0 +1,903 @@
+# Nushell Config File
+#
+# version = "0.98.0"
+
+# For more information on defining custom themes, see
+# https://www.nushell.sh/book/coloring_and_theming.html
+# And here is the theme collection
+# https://github.com/nushell/nu_scripts/tree/main/themes
+let dark_theme = {
+    # color for nushell primitives
+    separator: white
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    # eg) {|| if $in { 'light_cyan' } else { 'light_gray' } }
+    bool: light_cyan
+    int: white
+    filesize: cyan
+    duration: white
+    date: purple
+    range: white
+    float: white
+    string: white
+    nothing: white
+    binary: white
+    cell-path: white
+    row_index: green_bold
+    record: white
+    list: white
+    block: white
+    hints: dark_gray
+    search_result: { bg: red fg: white }
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_external_resolved: light_yellow_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b }
+    shape_glob_interpolation: cyan_bold
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_keyword: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
+    shape_raw_string: light_purple
+}
+
+let light_theme = {
+    # color for nushell primitives
+    separator: dark_gray
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    # eg) {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+    bool: dark_cyan
+    int: dark_gray
+    filesize: cyan_bold
+    duration: dark_gray
+    date: purple
+    range: dark_gray
+    float: dark_gray
+    string: dark_gray
+    nothing: dark_gray
+    binary: dark_gray
+    cell-path: dark_gray
+    row_index: green_bold
+    record: dark_gray
+    list: dark_gray
+    block: dark_gray
+    hints: dark_gray
+    search_result: { fg: white bg: red }
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_external_resolved: light_purple_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b }
+    shape_glob_interpolation: cyan_bold
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_keyword: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
+    shape_raw_string: light_purple
+}
+
+# External completer example
+# let carapace_completer = {|spans|
+#     carapace $spans.0 nushell ...$spans | from json
+# }
+
+# The default config record. This is where much of your global configuration is setup.
+$env.config = {
+    show_banner: true # true or false to enable or disable the welcome banner at startup
+
+    ls: {
+        use_ls_colors: true # use the LS_COLORS environment variable to colorize output
+        clickable_links: true # enable or disable clickable links. Your terminal has to support links.
+    }
+
+    rm: {
+        always_trash: false # always act as if -t was given. Can be overridden with -p
+    }
+
+    table: {
+        mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+        index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
+        show_empty: true # show 'empty list' and 'empty record' placeholders for command output
+        padding: { left: 1, right: 1 } # a left right padding of each column in a table
+        trim: {
+            methodology: wrapping # wrapping or truncating
+            wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
+            truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+        }
+        header_on_separator: false # show header text on separator/border line
+        # abbreviated_row_count: 10 # limit data rows from top and bottom after reaching a set point
+    }
+
+    error_style: "fancy" # "fancy" or "plain" for screen reader-friendly error messages
+
+    # Whether an error message should be printed if an error of a certain kind is triggered.
+    display_errors: {
+        exit_code: false # assume the external command prints an error message
+        # Core dump errors are always printed, and SIGPIPE never triggers an error.
+        # The setting below controls message printing for termination by all other signals.
+        termination_signal: true
+    }
+
+    # datetime_format determines what a datetime rendered in the shell would look like.
+    # Behavior without this configuration point will be to "humanize" the datetime display,
+    # showing something like "a day ago."
+    datetime_format: {
+        # normal: '%a, %d %b %Y %H:%M:%S %z'    # shows up in displays of variables or other datetime's outside of tables
+        # table: '%m/%d/%y %I:%M:%S%p'          # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
+    }
+
+    explore: {
+        status_bar_background: { fg: "#1D1F21", bg: "#C4C9C6" },
+        command_bar_text: { fg: "#C4C9C6" },
+        highlight: { fg: "black", bg: "yellow" },
+        status: {
+            error: { fg: "white", bg: "red" },
+            warn: {}
+            info: {}
+        },
+        selected_cell: { bg: light_blue },
+    }
+
+    history: {
+        max_size: 100_000 # Session has to be reloaded for this to take effect
+        sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
+        file_format: "plaintext" # "sqlite" or "plaintext"
+        isolation: false # only available with sqlite file_format. true enables history isolation, false disables it. true will allow the history to be isolated to the current session using up/down arrows. false will allow the history to be shared across all sessions.
+    }
+
+    completions: {
+        case_sensitive: false # set to true to enable case-sensitive completions
+        quick: true    # set this to false to prevent auto-selecting completions when only one remains
+        partial: true    # set this to false to prevent partial filling of the prompt
+        algorithm: "prefix"    # prefix or fuzzy
+        sort: "smart" # "smart" (alphabetical for prefix matching, fuzzy score for fuzzy matching) or "alphabetical"
+        external: {
+            enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
+            max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+            completer: null # check 'carapace_completer' above as an example
+        }
+        use_ls_colors: true # set this to true to enable file/path/directory completions using LS_COLORS
+    }
+
+    filesize: {
+        metric: false # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+        format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
+    }
+
+    cursor_shape: {
+        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (line is the default)
+        vi_insert: block # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (block is the default)
+        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (underscore is the default)
+    }
+
+    color_config: $dark_theme # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
+    footer_mode: 25 # always, never, number_of_rows, auto
+    float_precision: 2 # the precision for displaying floats in tables
+    buffer_editor: null # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+    use_ansi_coloring: true
+    bracketed_paste: true # enable bracketed paste, currently useless on windows
+    edit_mode: emacs # emacs, vi
+    shell_integration: {
+        # osc2 abbreviates the path if in the home_dir, sets the tab/window title, shows the running command in the tab/window title
+        osc2: true
+        # osc7 is a way to communicate the path to the terminal, this is helpful for spawning new tabs in the same directory
+        osc7: true
+        # osc8 is also implemented as the deprecated setting ls.show_clickable_links, it shows clickable links in ls output if your terminal supports it. show_clickable_links is deprecated in favor of osc8
+        osc8: true
+        # osc9_9 is from ConEmu and is starting to get wider support. It's similar to osc7 in that it communicates the path to the terminal
+        osc9_9: false
+        # osc133 is several escapes invented by Final Term which include the supported ones below.
+        # 133;A - Mark prompt start
+        # 133;B - Mark prompt end
+        # 133;C - Mark pre-execution
+        # 133;D;exit - Mark execution finished with exit code
+        # This is used to enable terminals to know where the prompt is, the command is, where the command finishes, and where the output of the command is
+        osc133: true
+        # osc633 is closely related to osc133 but only exists in visual studio code (vscode) and supports their shell integration features
+        # 633;A - Mark prompt start
+        # 633;B - Mark prompt end
+        # 633;C - Mark pre-execution
+        # 633;D;exit - Mark execution finished with exit code
+        # 633;E - Explicitly set the command line with an optional nonce
+        # 633;P;Cwd=<path> - Mark the current working directory and communicate it to the terminal
+        # and also helps with the run recent menu in vscode
+        osc633: true
+        # reset_application_mode is escape \x1b[?1l and was added to help ssh work better
+        reset_application_mode: true
+    }
+    render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
+    use_kitty_protocol: false # enables keyboard enhancement protocol implemented by kitty console, only if your terminal support this.
+    highlight_resolved_externals: false # true enables highlighting of external commands in the repl resolved by which.
+    recursion_limit: 50 # the maximum number of times nushell allows recursion before stopping it
+
+    plugins: {} # Per-plugin configuration. See https://www.nushell.sh/contributor-book/plugins.html#configuration.
+
+    plugin_gc: {
+        # Configuration for plugin garbage collection
+        default: {
+            enabled: true # true to enable stopping of inactive plugins
+            stop_after: 10sec # how long to wait after a plugin is inactive to stop it
+        }
+        plugins: {
+            # alternate configuration for specific plugins, by name, for example:
+            #
+            # gstat: {
+            #     enabled: false
+            # }
+        }
+    }
+
+    hooks: {
+        pre_prompt: [{ null }] # run before the prompt is shown
+        pre_execution: [{ null }] # run before the repl input is run
+        env_change: {
+            PWD: [{|before, after| null }] # run if the PWD environment is different since the last repl input
+        }
+        display_output: "if (term size).columns >= 100 { table -e } else { table }" # run to display the output of a pipeline
+        command_not_found: { null } # return an error message when a command is not found
+    }
+
+    menus: [
+        # Configuration for default nushell menus
+        # Note the lack of source parameter
+        {
+            name: completion_menu
+            only_buffer_difference: false
+            marker: "| "
+            type: {
+                layout: columnar
+                columns: 4
+                col_width: 20     # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+            }
+            style: {
+                text: green
+                selected_text: { attr: r }
+                description_text: yellow
+                match_text: { attr: u }
+                selected_match_text: { attr: ur }
+            }
+        }
+        {
+            name: ide_completion_menu
+            only_buffer_difference: false
+            marker: "| "
+            type: {
+                layout: ide
+                min_completion_width: 0,
+                max_completion_width: 50,
+                max_completion_height: 10, # will be limited by the available lines in the terminal
+                padding: 0,
+                border: true,
+                cursor_offset: 0,
+                description_mode: "prefer_right"
+                min_description_width: 0
+                max_description_width: 50
+                max_description_height: 10
+                description_offset: 1
+                # If true, the cursor pos will be corrected, so the suggestions match up with the typed text
+                #
+                # C:\> str
+                #      str join
+                #      str trim
+                #      str split
+                correct_cursor_pos: false
+            }
+            style: {
+                text: green
+                selected_text: { attr: r }
+                description_text: yellow
+                match_text: { attr: u }
+                selected_match_text: { attr: ur }
+            }
+        }
+        {
+            name: history_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: list
+                page_size: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        {
+            name: help_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: description
+                columns: 4
+                col_width: 20     # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+                selection_rows: 4
+                description_rows: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+    ]
+
+    keybindings: [
+        {
+            name: completion_menu
+            modifier: none
+            keycode: tab
+            mode: [emacs vi_normal vi_insert]
+            event: {
+                until: [
+                    { send: menu name: completion_menu }
+                    { send: menunext }
+                    { edit: complete }
+                ]
+            }
+        }
+        {
+            name: ide_completion_menu
+            modifier: control
+            keycode: char_n
+            mode: [emacs vi_normal vi_insert]
+            event: {
+                until: [
+                    { send: menu name: ide_completion_menu }
+                    { send: menunext }
+                    { edit: complete }
+                ]
+            }
+        }
+        {
+            name: history_menu
+            modifier: control
+            keycode: char_r
+            mode: [emacs, vi_insert, vi_normal]
+            event: { send: menu name: history_menu }
+        }
+        {
+            name: help_menu
+            modifier: none
+            keycode: f1
+            mode: [emacs, vi_insert, vi_normal]
+            event: { send: menu name: help_menu }
+        }
+        {
+            name: completion_previous_menu
+            modifier: shift
+            keycode: backtab
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menuprevious }
+        }
+        {
+            name: next_page_menu
+            modifier: control
+            keycode: char_x
+            mode: emacs
+            event: { send: menupagenext }
+        }
+        {
+            name: undo_or_previous_page_menu
+            modifier: control
+            keycode: char_z
+            mode: emacs
+            event: {
+                until: [
+                    { send: menupageprevious }
+                    { edit: undo }
+                ]
+            }
+        }
+        {
+            name: escape
+            modifier: none
+            keycode: escape
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: esc }    # NOTE: does not appear to work
+        }
+        {
+            name: cancel_command
+            modifier: control
+            keycode: char_c
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: ctrlc }
+        }
+        {
+            name: quit_shell
+            modifier: control
+            keycode: char_d
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: ctrld }
+        }
+        {
+            name: clear_screen
+            modifier: control
+            keycode: char_l
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: clearscreen }
+        }
+        {
+            name: search_history
+            modifier: control
+            keycode: char_q
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: searchhistory }
+        }
+        {
+            name: open_command_editor
+            modifier: control
+            keycode: char_o
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: openeditor }
+        }
+        {
+            name: move_up
+            modifier: none
+            keycode: up
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menuup }
+                    { send: up }
+                ]
+            }
+        }
+        {
+            name: move_down
+            modifier: none
+            keycode: down
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menudown }
+                    { send: down }
+                ]
+            }
+        }
+        {
+            name: move_left
+            modifier: none
+            keycode: left
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menuleft }
+                    { send: left }
+                ]
+            }
+        }
+        {
+            name: move_right_or_take_history_hint
+            modifier: none
+            keycode: right
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: historyhintcomplete }
+                    { send: menuright }
+                    { send: right }
+                ]
+            }
+        }
+        {
+            name: move_one_word_left
+            modifier: control
+            keycode: left
+            mode: [emacs, vi_normal, vi_insert]
+            event: { edit: movewordleft }
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: control
+            keycode: right
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: historyhintwordcomplete }
+                    { edit: movewordright }
+                ]
+            }
+        }
+        {
+            name: move_to_line_start
+            modifier: none
+            keycode: home
+            mode: [emacs, vi_normal, vi_insert]
+            event: { edit: movetolinestart }
+        }
+        {
+            name: move_to_line_start
+            modifier: control
+            keycode: char_a
+            mode: [emacs, vi_normal, vi_insert]
+            event: { edit: movetolinestart }
+        }
+        {
+            name: move_to_line_end_or_take_history_hint
+            modifier: none
+            keycode: end
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: historyhintcomplete }
+                    { edit: movetolineend }
+                ]
+            }
+        }
+        {
+            name: move_to_line_end_or_take_history_hint
+            modifier: control
+            keycode: char_e
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: historyhintcomplete }
+                    { edit: movetolineend }
+                ]
+            }
+        }
+        {
+            name: move_to_line_start
+            modifier: control
+            keycode: home
+            mode: [emacs, vi_normal, vi_insert]
+            event: { edit: movetolinestart }
+        }
+        {
+            name: move_to_line_end
+            modifier: control
+            keycode: end
+            mode: [emacs, vi_normal, vi_insert]
+            event: { edit: movetolineend }
+        }
+        {
+            name: move_up
+            modifier: control
+            keycode: char_p
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menuup }
+                    { send: up }
+                ]
+            }
+        }
+        {
+            name: move_down
+            modifier: control
+            keycode: char_t
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menudown }
+                    { send: down }
+                ]
+            }
+        }
+        {
+            name: delete_one_character_backward
+            modifier: none
+            keycode: backspace
+            mode: [emacs, vi_insert]
+            event: { edit: backspace }
+        }
+        {
+            name: delete_one_word_backward
+            modifier: control
+            keycode: backspace
+            mode: [emacs, vi_insert]
+            event: { edit: backspaceword }
+        }
+        {
+            name: delete_one_character_forward
+            modifier: none
+            keycode: delete
+            mode: [emacs, vi_insert]
+            event: { edit: delete }
+        }
+        {
+            name: delete_one_character_forward
+            modifier: control
+            keycode: delete
+            mode: [emacs, vi_insert]
+            event: { edit: delete }
+        }
+        {
+            name: delete_one_character_backward
+            modifier: control
+            keycode: char_h
+            mode: [emacs, vi_insert]
+            event: { edit: backspace }
+        }
+        {
+            name: delete_one_word_backward
+            modifier: control
+            keycode: char_w
+            mode: [emacs, vi_insert]
+            event: { edit: backspaceword }
+        }
+        {
+            name: move_left
+            modifier: none
+            keycode: backspace
+            mode: vi_normal
+            event: { edit: moveleft }
+        }
+        {
+            name: newline_or_run_command
+            modifier: none
+            keycode: enter
+            mode: emacs
+            event: { send: enter }
+        }
+        {
+            name: move_left
+            modifier: control
+            keycode: char_b
+            mode: emacs
+            event: {
+                until: [
+                    { send: menuleft }
+                    { send: left }
+                ]
+            }
+        }
+        {
+            name: move_right_or_take_history_hint
+            modifier: control
+            keycode: char_f
+            mode: emacs
+            event: {
+                until: [
+                    { send: historyhintcomplete }
+                    { send: menuright }
+                    { send: right }
+                ]
+            }
+        }
+        {
+            name: redo_change
+            modifier: control
+            keycode: char_g
+            mode: emacs
+            event: { edit: redo }
+        }
+        {
+            name: undo_change
+            modifier: control
+            keycode: char_z
+            mode: emacs
+            event: { edit: undo }
+        }
+        {
+            name: paste_before
+            modifier: control
+            keycode: char_y
+            mode: emacs
+            event: { edit: pastecutbufferbefore }
+        }
+        {
+            name: cut_word_left
+            modifier: control
+            keycode: char_w
+            mode: emacs
+            event: { edit: cutwordleft }
+        }
+        {
+            name: cut_line_to_end
+            modifier: control
+            keycode: char_k
+            mode: emacs
+            event: { edit: cuttolineend }
+        }
+        {
+            name: cut_line_from_start
+            modifier: control
+            keycode: char_u
+            mode: emacs
+            event: { edit: cutfromstart }
+        }
+        {
+            name: swap_graphemes
+            modifier: control
+            keycode: char_t
+            mode: emacs
+            event: { edit: swapgraphemes }
+        }
+        {
+            name: move_one_word_left
+            modifier: alt
+            keycode: left
+            mode: emacs
+            event: { edit: movewordleft }
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: alt
+            keycode: right
+            mode: emacs
+            event: {
+                until: [
+                    { send: historyhintwordcomplete }
+                    { edit: movewordright }
+                ]
+            }
+        }
+        {
+            name: move_one_word_left
+            modifier: alt
+            keycode: char_b
+            mode: emacs
+            event: { edit: movewordleft }
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: alt
+            keycode: char_f
+            mode: emacs
+            event: {
+                until: [
+                    { send: historyhintwordcomplete }
+                    { edit: movewordright }
+                ]
+            }
+        }
+        {
+            name: delete_one_word_forward
+            modifier: alt
+            keycode: delete
+            mode: emacs
+            event: { edit: deleteword }
+        }
+        {
+            name: delete_one_word_backward
+            modifier: alt
+            keycode: backspace
+            mode: emacs
+            event: { edit: backspaceword }
+        }
+        {
+            name: delete_one_word_backward
+            modifier: alt
+            keycode: char_m
+            mode: emacs
+            event: { edit: backspaceword }
+        }
+        {
+            name: cut_word_to_right
+            modifier: alt
+            keycode: char_d
+            mode: emacs
+            event: { edit: cutwordright }
+        }
+        {
+            name: upper_case_word
+            modifier: alt
+            keycode: char_u
+            mode: emacs
+            event: { edit: uppercaseword }
+        }
+        {
+            name: lower_case_word
+            modifier: alt
+            keycode: char_l
+            mode: emacs
+            event: { edit: lowercaseword }
+        }
+        {
+            name: capitalize_char
+            modifier: alt
+            keycode: char_c
+            mode: emacs
+            event: { edit: capitalizechar }
+        }
+        # The following bindings with `*system` events require that Nushell has
+        # been compiled with the `system-clipboard` feature.
+        # If you want to use the system clipboard for visual selection or to
+        # paste directly, uncomment the respective lines and replace the version
+        # using the internal clipboard.
+        {
+            name: copy_selection
+            modifier: control_shift
+            keycode: char_c
+            mode: emacs
+            event: { edit: copyselection }
+            # event: { edit: copyselectionsystem }
+        }
+        {
+            name: cut_selection
+            modifier: control_shift
+            keycode: char_x
+            mode: emacs
+            event: { edit: cutselection }
+            # event: { edit: cutselectionsystem }
+        }
+        # {
+        #     name: paste_system
+        #     modifier: control_shift
+        #     keycode: char_v
+        #     mode: emacs
+        #     event: { edit: pastesystem }
+        # }
+        {
+            name: select_all
+            modifier: control_shift
+            keycode: char_a
+            mode: emacs
+            event: { edit: selectall }
+        }
+    ]
+}
+
+# readline
+$env.config = {
+    edit_mode: vi
+  }

--- a/src/nvim/init.vim
+++ b/src/nvim/init.vim
@@ -1,0 +1,73 @@
+
+let mapleader=" "
+
+call plug#begin()
+
+Plug 'easymotion/vim-easymotion'
+Plug 'tpope/vim-surround'
+
+call plug#end()
+
+"设置Leade为空格
+let g:clipboard = g:vscode_clipboard    " Use vscode clipboard API
+" let g:EasyMotion_do_mapping = 0 " 禁用默认映射
+let g:EasyMotion_use_incsearch = 1 " 启用增量搜索
+let g:EasyMotion_smartcase = 1
+
+" Other settings
+" 映射 EasyMotion 命令
+nmap f <Plug>(easymotion-s)
+vmap f <Plug>(easymotion-s)
+nmap F <Plug>(easymotion-s2)
+
+" select all text in visual mode
+nnoremap <C-a> GVgg
+inoremap <C-a> <Esc>GVgg
+
+inoremap <C-j> <Esc>
+vnoremap <C-j> <Esc>
+
+"nnoremap o o <Esc>
+"nnoremap O O <Esc>
+" nnoremap <C-k> 5k
+"
+
+" 定义一个全局变量来存储输入法状态但是
+" let g:last_im_select = '2052'
+
+" 在退出插入模式时保存当前输入法状态
+" autocmd InsertLeave * let g:last_im_select = system('D:/OneDrive/im_select/im-select.exe'):
+
+" 在进入插入模式时恢复输入法状态
+" autocmd InsertEnter * if !empty(g:last_im_select) | silent execute '!D:/OneDrive/im_select/im-select.exe 1033'| endif
+" autocmd InsertEnter * if !empty(g:last_im_select) | silent execute '!D:/OneDrive/im_select/im-select.exe ' . g:last_im_select | endif
+
+
+" 定义一个函数来切换输入法
+function! ToggleEnglish()
+    silent !D:/OneDrive/im_select/im-select.exe 1033
+endfunction
+
+function! ToggleCn()
+    silent !D:/OneDrive/im_select/im-select.exe 2052
+endfunction
+
+
+" 在退出插入模式时切换到英文输入法
+autocmd InsertLeave * silent !D:/OneDrive/im_select/im-select.exe 1033
+" 在退出 Vim 时切换到cn输入法
+autocmd VimLeave * call ToggleCn()
+autocmd VimEnter * call ToggleEnglish()
+
+" 映射 Esc 键到这个函数
+nnoremap <silent> <Esc> :call ToggleEnglish()<CR>
+
+
+
+set ignorecase              " Ignore upper case or lower case when searching
+set smartcase               " Override 'ignorecase' if there are upper case chars
+set nohls                   " Don't highlight searching result
+set fileformat=unix         " Set end of line style to LF
+set clipboard+=unnamedplus  " Share system clipboard
+
+

--- a/src/starship/install.sh
+++ b/src/starship/install.sh
@@ -1,0 +1,8 @@
+
+# aim_dir="~/sssssss.toml"
+# mkdir -p ~/.config && touch $aim_dir
+echo $(dirname "$0")
+
+# cp "$(dirname "$0")/starship.toml" $aim_dir
+
+# cd ~ && y

--- a/src/starship/readme.md
+++ b/src/starship/readme.md
@@ -1,0 +1,3 @@
+# starship
+
+[orgin website](https://starship.rs/guide/)

--- a/src/starship/starship.toml
+++ b/src/starship/starship.toml
@@ -1,0 +1,288 @@
+format = """
+[░▒▓](color_orange)\
+$username\
+[](bg:color_yellow fg:color_orange)\
+$directory\
+[](fg:color_yellow bg:color_aqua)\
+$git_branch\
+$git_status\
+[](fg:color_aqua bg:color_blue)\
+$c\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[](fg:color_blue bg:color_bg3)\
+$docker_context\
+$conda\
+[](fg:color_bg3 bg:color_bg1)\
+$time\
+[](fg:color_bg1 bg:color_orange)\
+$cmd_duration\
+[ ](fg:color_orange)\
+$line_break$os$character\
+"""
+
+palette = 'gruvbox_dark'
+
+[username]
+show_always = true
+style_user = "bg:color_orange fg:color_fg0"
+style_root = "bg:color_orange fg:color_fg0"
+format = '[ $user ]($style)'
+
+[git_branch]
+symbol = ""
+style = "bg:color_aqua"
+format = '[[ $symbol $branch ](fg:color_fg0 bg:color_aqua)]($style)'
+# symbol = '🌱 '
+truncation_length = 4
+truncation_symbol = ''
+
+
+[cmd_duration]
+min_time = 10
+show_milliseconds = true
+disabled = false
+style = "bg:color_bg1"
+format = '[[ $duration](fg:color_fg0 bg:color_orange)]($style)'
+
+
+[git_state]
+# format = '[\($state( $progress_current of $progress_total)\)]($style) '
+cherry_pick = '[🍒 PICKING](bold red)'
+
+[git_metrics]
+added_style = 'bold blue'
+format = '[+$added]($added_style)/[-$deleted]($deleted_style)'
+
+# ~/.config/starship.toml
+[directory]
+style = "fg:color_fg0 bg:color_yellow"
+format = "[ $path ]($style)"
+truncation_length = 3
+# Here is how you can shorten some long paths by text replacement
+# similar to mapped_locations in Oh My Posh:
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+
+[git_status]
+conflicted = '🏳'
+ahead = '🏎💨'
+behind = '😰'
+diverged = '😵'
+up_to_date = '✓'
+untracked = '🤷'
+stashed = '📦'
+modified = '📝'
+staged = '[++\($count\)](green)'
+renamed = '👅'
+deleted = '🗑'
+style = "bg:color_aqua"
+format = '[[($all_status$ahead_behind )](fg:color_fg0 bg:color_aqua)]($style)'
+
+[golang]
+# symbol = ""
+symbol = "🐹 "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[os]
+disabled = false
+# style = "fg:color_fg0 bg:color_orange"
+# format = '[$symbol]($style)'
+
+[time]
+disabled = false
+time_format = "%R"
+style = "bg:color_bg1"
+format = '[[  $time ](fg:color_fg0 bg:color_bg1)]($style)'
+
+[line_break]
+disabled = false
+
+[character]
+disabled = false
+success_symbol = '[](bold fg:color_green)'
+error_symbol = '[](bold fg:color_red)'
+vimcmd_symbol = '[](bold fg:color_green)'
+vimcmd_replace_one_symbol = '[](bold fg:color_purple)'
+vimcmd_replace_symbol = '[](bold fg:color_purple)'
+vimcmd_visual_symbol = '[](bold fg:color_yellow)'
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+Arch = "󰣇"
+Artix = "󰣇"
+EndeavourOS = ""
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+[aws]
+symbol = "  "
+[c]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+
+[php]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[java]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[python]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:color_bg3"
+format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[conda]
+style = "bg:color_bg3"
+format = '[[ $symbol( $environment) ](fg:#83a598 bg:color_bg3)]($style)'
+[buf]
+symbol = " "
+
+
+[crystal]
+symbol = " "
+
+[dart]
+symbol = " "
+
+
+[elixir]
+symbol = " "
+
+[elm]
+symbol = " "
+
+[fennel]
+symbol = " "
+
+[fossil_branch]
+symbol = " "
+
+
+[guix_shell]
+symbol = " "
+
+
+[haxe]
+symbol = " "
+
+[hg_branch]
+symbol = " "
+
+[hostname]
+ssh_symbol = " "
+
+
+[julia]
+symbol = " "
+
+
+[lua]
+symbol = " "
+
+[memory_usage]
+symbol = "󰍛 "
+
+[meson]
+symbol = "󰔷 "
+
+[nim]
+symbol = "󰆥 "
+
+[nix_shell]
+symbol = " "
+
+[nodejs]
+symbol = " "
+
+[ocaml]
+symbol = " "
+
+
+[package]
+symbol = "󰏗 "
+
+[perl]
+symbol = " "
+
+
+[pijul_channel]
+symbol = " "
+
+
+[rlang]
+symbol = "󰟔 "
+
+[ruby]
+symbol = " "
+
+
+[scala]
+symbol = " "
+
+[swift]
+symbol = " "
+
+[zig]
+symbol = " "
+
+[palettes.gruvbox_dark]
+color_fg0 = '#fbf1c7'
+color_bg1 = '#3c3836'
+color_bg3 = '#665c54'
+color_blue = '#458588'
+color_aqua = '#689d6a'
+color_green = '#98971a'
+color_orange = '#d65d0e'
+color_purple = '#b16286'
+color_red = '#cc241d'
+color_yellow = '#d79921'

--- a/src/yazi/config/yazi.toml
+++ b/src/yazi/config/yazi.toml
@@ -1,0 +1,20 @@
+[manager]
+ratio=[1,3,4]
+
+[preview]
+wrap="yes"
+
+[opener]
+edit = [
+	{ run = 'nvim "$@"', block = true, for = "unix" },
+	{ run = "nvim %0",   block = true, for = "windows" },
+]
+play = [
+	{ run = 'mpv "$@"', orphan = true, for = "unix" },
+	{ run = '"C:\Program Files\mpv.exe" %*', orphan = true, for = "windows" }
+]
+open = [
+
+	{ run = 'nvim "$@"', block = true, for = "unix" ,desc = "open"},
+	{ run = "nvim %0",   block = true, for = "windows",desc = "open" },
+]


### PR DESCRIPTION
Extended the README to better explain the purpose of the `system-config` file. The updated description clarifies that the file is used to store system configurations, specifically mentioning example configurations such as yazi, zsh, and nushell.